### PR TITLE
Update sha256 checksum and README

### DIFF
--- a/Formula/materialize.rb
+++ b/Formula/materialize.rb
@@ -3,7 +3,7 @@ class Materialize < Formula
   homepage "https://materialize.io/docs/"
   url "https://github.com/MaterializeInc/materialize/archive/v0.1.0.tar.gz"
   version "v0.1.0"
-  sha256 "43de4b569f4a377529287bf7b3a62e6b000f307617cbc9463dda425ba7b6d2dc"
+  sha256 "2bf26562eb1f5eb20ff661781b07e4714a9a2f934d5131b3705a2ba15c558431"
 
   depends_on "rust" => :build
   # cmake is required for rdkafka because it depends on librdkafka

--- a/Formula/materialize.rb
+++ b/Formula/materialize.rb
@@ -3,7 +3,7 @@ class Materialize < Formula
   homepage "https://materialize.io/docs/"
   url "https://github.com/MaterializeInc/materialize/archive/v0.1.0.tar.gz"
   version "v0.1.0"
-  sha256 "07570f3658f57fceee43bb0fb38abbabedb92008"
+  sha256 "43de4b569f4a377529287bf7b3a62e6b000f307617cbc9463dda425ba7b6d2dc"
 
   depends_on "rust" => :build
   # cmake is required for rdkafka because it depends on librdkafka

--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ brew install materialize
 To update the version of Materialize distributed by this Homebrew
 Formula, make the following changes:
 - Update the `url` attribute to point to the correct release tarball.
-- Update the `commit` attribute (and the `MZ_DEV_BUILD_SHA` attribute)
-  to use the most recent commit from the targeted release.
+- Update the `sha256` attribute. To get the new checksum, download the
+  tarball of the target Materialize release and run:
+  ```shell script
+  curl -L "https://github.com/MaterializeInc/materialize/archive/<version_you_want>.tar.gz" -o materialize.tar.gz
+  openssl sha256 materialize.tar.gz
+  ```
+- Update the `MZ_DEV_BUILD_SHA` to use the most recent Git commit
+  from the targeted release.
   
 Test that you can pull it down locally! `cd` to this repo and run:
 ```shell script


### PR DESCRIPTION
It turns out I didn't actually know what the `sha256` field was 🎉.

This PR updates to the right checksum for our first release and fixes documentation for how to update the Formula in the future.