### PR TITLE
Split developer and user docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+### Updating the Formula
+
+To update the version of Materialize distributed by this Homebrew
+Formula, make the following changes:
+
+- Update the `url` attribute to point to the correct release tarball.
+- Update the `sha256` attribute. To get the new checksum, download the
+  tarball of the target Materialize release and run:
+
+  ```shell
+  curl -L "https://github.com/MaterializeInc/materialize/archive/<version_you_want>.tar.gz" -o materialize.tar.gz
+  openssl sha256 materialize.tar.gz
+  ```
+
+- Update the `MZ_DEV_BUILD_SHA` to use the most recent Git commit
+  from the targeted release.
+
+Test that you can pull it down locally! `cd` to this repo and run:
+```shell script
+brew install --verbose --debug materialize
+```
+
+Then, just submit a PR and merge!

--- a/README.md
+++ b/README.md
@@ -1,35 +1,18 @@
 # homebrew-materialize
 
-This repository contains all components and information about 
-the Materialize homebrew package.
+A [Homebrew] tap for installing [Materialize], the streaming data warehouse.
+This tap always installs the latest stable release of `materialized`.
 
-### To Install Materialize
+For installation options besides Homebrew, see
+<https://materialize.io/docs/install>.
 
-To install Materialize via Homebrew, run the following two commands:
-```shell script
-brew tap MaterializeInc/homebrew-materialize
-brew install materialize
+### Installation instructions
+
+With [Homebrew] installed, run:
+
+```shell
+brew install MaterializeInc/materialize/materialized
 ```
 
-### Internal use: Update the Formula
-
-To update the version of Materialize distributed by this Homebrew
-Formula, make the following changes:
-- Update the `url` attribute to point to the correct release tarball.
-- Update the `sha256` attribute. To get the new checksum, download the
-  tarball of the target Materialize release and run:
-  ```shell script
-  curl -L "https://github.com/MaterializeInc/materialize/archive/<version_you_want>.tar.gz" -o materialize.tar.gz
-  openssl sha256 materialize.tar.gz
-  ```
-- Update the `MZ_DEV_BUILD_SHA` to use the most recent Git commit
-  from the targeted release.
-  
-Test that you can pull it down locally! `cd` to this repo and run:
-```shell script
-brew install --verbose --debug materialize
-```
-
-Then, just submit a PR and merge!
-   
-
+[Materialize]: https://materialize.io
+[Homebrew]: https://brew.sh


### PR DESCRIPTION
Move the developer docs out of the README and into CONTRIBUTING.md, so
that end users only see the installation instructions.

Also fixes #2!