### PR TITLE
Improve test

### DIFF
--- a/Formula/materialized.rb
+++ b/Formula/materialized.rb
@@ -1,5 +1,5 @@
-class Materialize < Formula
-  desc "Official Materialize command-line interface"
+class Materialized < Formula
+  desc "The streaming data warehouse"
   homepage "https://materialize.io/docs/"
   url "https://github.com/MaterializeInc/materialize/archive/v0.1.0.tar.gz"
   version "v0.1.0"
@@ -9,17 +9,27 @@ class Materialize < Formula
   # cmake is required for rdkafka because it depends on librdkafka
   depends_on "cmake" => :build
 
+  BUILD_SHA = "07570f3658f57fceee43bb0fb38abbabedb92008"
+
   def install
     # Materialize uses a procedural macro that invokes "git" in order to embed
     # the current SHA in the built binary. The MZ_DEV_BUILD_SHA variable
     # blocks that macro from running at build-time.
-    ENV['MZ_DEV_BUILD_SHA'] = "07570f3658f57fceee43bb0fb38abbabedb92008"
+    ENV["MZ_DEV_BUILD_SHA"] = BUILD_SHA
     system "cargo", "build", "--release", "--bin", "materialized"
     bin.install "target/release/materialized"
   end
 
   test do
-    # todo: Write a better test!
-    system "#{bin}/materialized", "--version"
+    pid = fork do
+      exec bin/"materialized"
+    end
+    sleep 2
+
+    output = shell_output("curl 127.0.0.1:6875")
+    assert_includes output, BUILD_SHA
+  ensure
+    Process.kill(9, pid)
+    Process.wait(pid)
   end
 end


### PR DESCRIPTION
This test isn't the most robust, but it matches what homebrew-core does
for MySQL.

Also rename the formula to "materialized" to match the Homebrew
convention that a formula matches the name of the binary it installs,
and to match the apt package.