### PR TITLE
Build bottles for High Sierra, not Catalina

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         brew install gnu-tar
         metadata=$(brew info --json materialized)
         version=$(jq -r .[0].versions.stable <<< "$metadata")
-        bottle_hash=$(jq -r .[0].bottle.stable.files.catalina.sha256 <<< "$metadata")
+        bottle_hash=$(jq -r .[0].bottle.stable.files.high_sierra.sha256 <<< "$metadata")
         sha=$(git ls-remote https://github.com/MaterializeInc/materialize.git "v$version^{}" | cut -f1)
         echo "::set-env name=MATERIALIZED_VERSION::$version"
         echo "version=$version" "sha=$sha" "bottle_hash=$bottle_hash"
@@ -32,9 +32,9 @@ jobs:
           exit 1
         fi
         bin/mkbottle "$version"
-        echo "$bottle_hash  materialized-$version.catalina.bottle.tar.gz" | shasum -a 256 --check
+        echo "$bottle_hash  materialized-$version.high_sierra.bottle.tar.gz" | shasum -a 256 --check
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: materialized.catalina.bottle.tar.gz
-        path: materialized-${{env.MATERIALIZED_VERSION}}.catalina.bottle.tar.gz
+        name: materialized.high_sierra.bottle.tar.gz
+        path: materialized-${{env.MATERIALIZED_VERSION}}.high_sierra.bottle.tar.gz

--- a/Formula/materialized.rb
+++ b/Formula/materialized.rb
@@ -7,7 +7,7 @@ class Materialized < Formula
 
   bottle do
     root_url "https://downloads.mtrlz.dev"
-    sha256 "90c97cf014dc846c3f5f223de3e8b96a0037d37f012e7a5d7277fa664e8208e5" => :catalina
+    sha256 "1741ce67a3e7408b965876c76a910734380314e27c2486ee66ff9277611b225b" => :high_sierra
   end
 
   depends_on "cmake" => :build

--- a/bin/mkbottle
+++ b/bin/mkbottle
@@ -68,7 +68,7 @@ sed "/^  bottle do/,/^  end/d" "$OLDPWD/Formula/materialized.rb" > "$prefix/.bre
 # Make the tarballs reproducible (given an official Materialize release tarball)
 # so that CI can check that the bottle it downloads is, in fact, the output of
 # this script at the tested revision.
-bottle="$OLDPWD/materialized-$version.catalina.bottle.tar.gz"
+bottle="$OLDPWD/materialized-$version.high_sierra.bottle.tar.gz"
 gtar \
   --sort=name \
   --mtime="./$prefix/bin/materialized" \
@@ -78,7 +78,7 @@ gtar \
   | gzip -n > "$bottle"
 
 if [[ ! "${GITHUB_WORKFLOW:-}" ]]; then
-  s3_path="s3://downloads.mtrlz.dev/materialized-$version.catalina.bottle.tar.gz"
+  s3_path="s3://downloads.mtrlz.dev/materialized-$version.high_sierra.bottle.tar.gz"
   aws s3 cp --acl public-read "$bottle" "$s3_path"
   echo "uploaded bottle to $s3_path"
   shasum -a 256 "$bottle"


### PR DESCRIPTION
We need to build bottles for the oldest macOS version we want to
support. The last three versions seems reasonable; it's what Homebrew
does, at least. Downgrade the bottle to a bottle built for High Sierra.
Homebrew will automatically use this bottle even on newer versions of
macOS.