### PR TITLE
Switch from s3 to Bintray for bottle storage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
         mkdir -p "$(dirname $(brew --repo ${{github.repository}}))"
         cp -a "$GITHUB_WORKSPACE" "$(brew --repo ${{github.repository}})"
         brew install gnu-tar
+        brew install gzip
+        hash -r gzip
         metadata=$(brew info --json materialized)
         version=$(jq -r .[0].versions.stable <<< "$metadata")
         bottle_hash=$(jq -r .[0].bottle.stable.files.high_sierra.sha256 <<< "$metadata")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,18 @@ changes:
 - Update the `STABLE_BUILD_SHA` to reflect the full commit SHA for the
   selected release.
 
-- Publish a bottle for the new version by running `bin/mkbottle VERSION`. You
-  will need to be a Materialize employee with permissions to write to the
-  downloads.mtrlz.dev S3 bucket to perform this step.
+- Publish a bottle for the new version by running `bin/mkbottle VERSION`.
+  You will need a file in `$HOME/.netrc` with a line like the following:
+  ```
+  machine api.bintray.com login <your Bintray username> password <your Bintray API key>
+  ```
+
+  Note that your API key is not the same as your account password. It can be found
+  via [these instructions](https://www.jfrog.com/confluence/display/BT/Uploading#Uploading-GettingyourAPIKey).
+
+- Note the SHA hash printed at the end of the `bin/mkbottle` command, and
+  update the `sha256` attribute under the `bottle` section of `Formula/materialized.rb`
+  accordingly.
 
 Then, submit a PR! CI will automatically test that the formula installs and
 runs properly.

--- a/Formula/materialized.rb
+++ b/Formula/materialized.rb
@@ -6,8 +6,8 @@ class Materialized < Formula
   head "https://github.com/MaterializeInc/materialize.git"
 
   bottle do
-    root_url "https://downloads.mtrlz.dev"
-    sha256 "a14fb6a49a4f5e52e08ea37e02f0abf7f35889f92ba33017e428fbeac41fca20" => :high_sierra
+    root_url "https://packages.materialize.io/homebrew"
+    sha256 "84f9b4c05680e3e84f0f1f0af6a0dafc293624f3cccee8faabb7e95096dfa8a9" => :high_sierra
   end
 
   depends_on "cmake" => :build

--- a/bin/mkbottle
+++ b/bin/mkbottle
@@ -24,7 +24,7 @@ trap "rm -rf $tmpdir" EXIT
 # release binaries on GitHub's macOS infrastructure is unbearably slow.
 #
 # [0]: https://jonathanchang.org/blog/maintain-your-own-homebrew-repository-with-binary-bottles/
-curl -L https://downloads.mtrlz.dev/materialized-v$version-x86_64-apple-darwin.tar.gz | tar x
+curl -L https://downloads.mtrlz.dev/materialized-v$version-x86_64-apple-darwin.tar.gz | tar xz
 mv materialized materialized.orig
 mkdir -p "$prefix/.brew"
 mv materialized.orig/* "$prefix"
@@ -69,7 +69,12 @@ sed "/^  bottle do/,/^  end/d" "$OLDPWD/Formula/materialized.rb" > "$prefix/.bre
 # so that CI can check that the bottle it downloads is, in fact, the output of
 # this script at the tested revision.
 bottle="$OLDPWD/materialized-$version.high_sierra.bottle.tar.gz"
-gtar \
+if tar --version | grep -q "GNU tar"; then
+  TAR_CMD=tar
+else
+  TAR_CMD=gtar
+fi
+"$TAR_CMD" \
   --sort=name \
   --mtime="./$prefix/bin/materialized" \
   --owner=0 --group=0 --numeric-owner \
@@ -78,8 +83,16 @@ gtar \
   | gzip -n > "$bottle"
 
 if [[ ! "${GITHUB_WORKFLOW:-}" ]]; then
-  s3_path="s3://downloads.mtrlz.dev/materialized-$version.high_sierra.bottle.tar.gz"
-  aws s3 cp --acl public-read "$bottle" "$s3_path"
-  echo "uploaded bottle to $s3_path"
+  curl -n -f -X POST -H "Content-Type: application/json" -d "
+    {
+        \"name\": \"$version\",
+        \"vcs_tag\": \"v$version\",
+    }" \
+    https://api.bintray.com/packages/materialize/homebrew/materialized/versions
+  echo
+  echo "Created Bintray version"
+  curl -n -f -T "$bottle" "https://api.bintray.com/content/materialize/homebrew/materialized/$version/materialized-$version.high_sierra.bottle.tar.gz;publish=1"
+  echo
+  echo "Uploaded and published bottle to Bintray"
   shasum -a 256 "$bottle"
 fi


### PR DESCRIPTION
This switches to Bintray for storing our bottles, allowing us to collect download statistics.

It also makes a few changes to `bin/mkbottle` allowing it to run on non-macOS systems (tested on Ubuntu 20.04).