### PR TITLE
Add launchd service

### DIFF
--- a/Formula/materialized.rb
+++ b/Formula/materialized.rb
@@ -35,6 +35,41 @@ class Materialized < Formula
                                "--path", "src/materialized"
   end
 
+  def caveats; <<~EOS
+    The launchd service will use only one worker thread. For improved
+    performance, consider manually starting materialized and tuning the
+    number of worker threads based on your hardware:
+        materialized --threads=N
+  EOS
+  end
+
+
+  plist_options :manual => "materialized --threads=1"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/materialized</string>
+        <string>--data-directory=#{var}/materialized</string>
+        <string>--threads=1</string>
+      </array>
+      <key>WorkingDirectory</key>
+      <string>#{var}</string>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+    </dict>
+    </plist>
+  EOS
+  end
+
   test do
     pid = fork do
       exec bin/"materialized", "-w1"


### PR DESCRIPTION
Add a launchd service that can run materialized in the background via
`brew services`.

Fix #21.

Here's how the installation message looks:

```
==> Caveats
The launchd service will use only one worker thread. For improved
performance, consider manually starting materialized and tuning the
number of worker threads based on your hardware:
    materialized --threads=N

To have launchd start materializeinc/materialize/materialized now and restart at login:
  brew services start materializeinc/materialize/materialized
Or, if you don't want/need a background service you can just run:
  materialized --threads=1
==> Summary
🍺  /usr/local/Cellar/materialized/0.3.0: 4 files, 50.9MB
```