### PR TITLE
Address deprecation warning

### DIFF
--- a/Formula/materialized.rb
+++ b/Formula/materialized.rb
@@ -7,7 +7,7 @@ class Materialized < Formula
 
   bottle do
     root_url "https://packages.materialize.io/homebrew"
-    sha256 "e4d9a590549434f54a85077822fe8eb8b67ef6cbd316addb47c38ff5c7dead55" => :high_sierra
+    sha256 high_sierra: "e4d9a590549434f54a85077822fe8eb8b67ef6cbd316addb47c38ff5c7dead55"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Brew currently produces the following deprecation message
```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the materializeinc/materialize tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/materializeinc/homebrew-materialize/Formula/materialized.rb:10
```
