### PR TITLE
mz (CLI) formula

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,9 @@ jobs:
         cp -a "$GITHUB_WORKSPACE" "$(brew --repo ${{github.repository}})"
         brew install docker docker-machine
         brew services start docker-machine
+        mkdir -p ~/.docker/machine/cache/
         curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
-        docker-machine create --driver virtualbox --virtualbox-hostonly-cidr 192.168.63.1/24 default
+        docker-machine create --driver virtualbox --virtualbox-boot2docker-url ~/.docker/machine/cache/boot2docker.iso --virtualbox-hostonly-cidr 192.168.63.1/24 default
         eval $(docker-machine env default)
         for formula in materialized; do
           metadata=$(brew info --json $formula)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
-    - name: Test materialized formula
+    - name: Test formulas
       # Ideally we would test a) building from source for the current
       # version, b) building from source for HEAD, and c) pouring the pre-built
       # bottle. Unfortunately building from source on GitHub VMs takes 30m+,
@@ -24,31 +24,33 @@ jobs:
         brew services start docker-machine
         docker-machine create --driver virtualbox --virtualbox-hostonly-cidr 192.168.63.1/24 default
         eval $(docker-machine env default)
-        metadata=$(brew info --json materialized)
-        version=$(jq -r .[0].versions.stable <<< "$metadata")
-        sha=$(git ls-remote https://github.com/MaterializeInc/materialize.git "v$version^{}" | cut -f1)
-        echo "MATERIALIZED_VERSION=$version" >> "$GITHUB_ENV"
-        echo "version=$version" "sha=$sha"
-        set -x
-        brew fetch --build-from-source materialized
-        brew fetch --HEAD materialized
-        brew install materialized
-        brew linkage --test materialized
-        brew test materialized --verbose
-        set +x
-        if ! materialized --version 2>&1 | grep "${sha:0:9}"; then
-          echo "materialized --version reports wrong version" >&2
-          materialized --version
-          exit 1
-        fi
-        for platform in mojave arm64_big_sur; do
-          bottle_hash=$(jq -r .[0].bottle.stable.files."$platform".sha256 <<< "$metadata")
-          echo "bottle_hash=$bottle_hash"
-          bin/mkbottle "$version" "$platform"
-          echo "$bottle_hash  bottle.$platform.tar.gz" | shasum -a 256 --check
+        for formula in materialized; do
+          metadata=$(brew info --json $formula)
+          version=$(jq -r .[0].versions.stable <<< "$metadata")
+          sha=$(git ls-remote https://github.com/MaterializeInc/materialize.git "v$version^{}" | cut -f1)
+          echo "FORMULA_VERSION=$version" >> "$GITHUB_ENV"
+          echo "version=$version" "sha=$sha"
+          set -x
+          brew fetch --build-from-source $formula
+          brew fetch --HEAD $formula
+          brew install $formula
+          brew linkage --test $formula
+          brew test $formula --verbose
+          set +x
+          if ! $formula --version 2>&1 | grep "${sha:0:9}"; then
+            echo "$formula --version reports wrong version" >&2
+            $formula --version
+            exit 1
+          fi
+          for platform in mojave arm64_big_sur; do
+            bottle_hash=$(jq -r .[0].bottle.stable.files."$platform".sha256 <<< "$metadata")
+            echo "bottle_hash=$bottle_hash"
+            bin/mkbottle "$version" "$platform" "$formula"
+            echo "$bottle_hash  bottle.$platform.tar.gz" | shasum -a 256 --check
+          done
         done
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
         name: bottle
-        path: materialized-${{env.MATERIALIZED_VERSION}}.*.bottle.tar.gz
+        path: $formula-${{env.FORMULA_VERSION}}.*.bottle.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         cp -a "$GITHUB_WORKSPACE" "$(brew --repo ${{github.repository}})"
         brew install docker docker-machine
         brew services start docker-machine
+        curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
         docker-machine create --driver virtualbox --virtualbox-hostonly-cidr 192.168.63.1/24 default
         eval $(docker-machine env default)
         for formula in materialized; do

--- a/Formula/mz.rb
+++ b/Formula/mz.rb
@@ -1,0 +1,23 @@
+class Mz < Formula
+    version '0.0.0'
+    desc "Command-line interface (CLI) for Materialize."
+    homepage "https://materialize.io/docs/"
+    url "https://github.com/MaterializeInc/materialize/archive/refs/tags/v0.27.0-alpha.22.tar.gz"
+    sha256 "5cc8bcbe2643fc48a08f853e13efe005c3f9f357b66c51ac428be6271d896500"
+    head "https://github.com/MaterializeInc/materialize.git", branch: "main"
+
+    depends_on "cmake" => :build
+    depends_on "rust" => :build
+
+    if OS.mac?
+        depends_on "libpq" => :build
+    elsif OS.linux?
+        depends_on "postgresql-client" => :build
+    end
+
+    def install
+        system "cargo", "install", "--locked",
+                                   "--root", prefix,
+                                   "--path", "src/mz"
+    end
+end

--- a/Formula/mz.rb
+++ b/Formula/mz.rb
@@ -2,7 +2,7 @@ class Mz < Formula
     version '0.0.0'
     desc "Command-line interface (CLI) for Materialize."
     homepage "https://materialize.io/docs/"
-    url "https://github.com/MaterializeInc/materialize/archive/refs/tags/v0.27.0-alpha.22.tar.gz"
+    url "https://github.com/MaterializeInc/materialize/archive/refs/tags/v0.27.0-alpha.26.tar.gz"
     sha256 "5cc8bcbe2643fc48a08f853e13efe005c3f9f357b66c51ac428be6271d896500"
     head "https://github.com/MaterializeInc/materialize.git", branch: "main"
 

--- a/Formula/mz.rb
+++ b/Formula/mz.rb
@@ -6,14 +6,15 @@ class Mz < Formula
     sha256 "5cc8bcbe2643fc48a08f853e13efe005c3f9f357b66c51ac428be6271d896500"
     head "https://github.com/MaterializeInc/materialize.git", branch: "main"
 
+    bottle do
+        root_url "http://homebrew.materialize.com"
+        sha256 arm64_big_sur: "TBD"
+        sha256 mojave: "TBD"
+    end
+
     depends_on "cmake" => :build
     depends_on "rust" => :build
-
-    if OS.mac?
-        depends_on "libpq" => :build
-    elsif OS.linux?
-        depends_on "postgresql-client" => :build
-    end
+    depends_on "libpq" => :build
 
     def install
         system "cargo", "install", "--locked",

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-# Automatically updates the tap for a newly-released version of materialized.
+# Automatically updates the tap for a newly-released version.
 
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "usage: $0 VERSION" >&2
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 VERSION FORMULA" >&2
   exit 1
 fi
 
@@ -15,8 +15,9 @@ AWS_PROFILE=${AWS_PROFILE:-mz-core-admin}
 export AWS_PROFILE
 
 version=${1#v}
+formula=$2
 
-echo "Fetching metadata for materialized v$version..."
+echo "Fetching metadata for $formula v$version..."
 url=https://github.com/MaterializeInc/materialize/archive/v$version.tar.gz
 archive_sha=$(curl -fsSL "$url" | openssl sha256 | sed -e 's/(stdin)= //' -e 's/^SHA256//')
 build_sha=$(git ls-remote https://github.com/MaterializeInc/materialize.git "v$version^{}" | cut -f1)
@@ -26,7 +27,7 @@ echo "Source archive SHA-256: $archive_sha"
 echo "Build commit SHA-1:     $build_sha"
 
 echo "Updating formula for new source tarball..."
-sed -f /dev/stdin Formula/materialized.rb > Formula/materialized.rb.new <<EOF
+sed -f /dev/stdin Formula/$formula.rb > Formula/$formula.rb.new <<EOF
 /^  url/c\\
 \  url "$url"
 /^  sha256/c\\
@@ -34,38 +35,38 @@ sed -f /dev/stdin Formula/materialized.rb > Formula/materialized.rb.new <<EOF
 /^  STABLE_BUILD_SHA/c\\
 \  STABLE_BUILD_SHA = "$build_sha".freeze
 EOF
-mv Formula/materialized.rb{.new,}
+mv Formula/$formula.rb{.new,}
 
 for platform in mojave arm64_big_sur; do
   echo "Building bottle..."
-  bin/mkbottle "$version" "$platform"
+  bin/mkbottle "$version" "$platform" "$formula"
 
-  echo "Uploading bottle to S3..."
-  if ! aws s3 cp bottle.$platform.tar.gz "s3://materialize-homebrew/materialized-$version.$platform.bottle.tar.gz"; then
-    echo
-    echo "Uploading to S3 failed." >&2
-    echo "AWS CLI access is documented here: https://github.com/MaterializeInc/i2/blob/main/doc/aws-access.md" >&2
-    echo "Ask for any clarification in #release on Slack." >&2
-    echo "Note:"
-    echo "    You need to be logged in to the mz-core-admin account"
-    exit 1
-  fi
+  # echo "Uploading bottle to S3..."
+  # if ! aws s3 cp bottle.$platform.tar.gz "s3://materialize-homebrew/$formula-$version.$platform.bottle.tar.gz"; then
+  #   echo
+  #   echo "Uploading to S3 failed." >&2
+  #   echo "AWS CLI access is documented here: https://github.com/MaterializeInc/i2/blob/main/doc/aws-access.md" >&2
+  #   echo "Ask for any clarification in #release on Slack." >&2
+  #   echo "Note:"
+  #   echo "    You need to be logged in to the mz-core-admin account"
+  #   exit 1
+  # fi
 
   echo "Updating formula for new bottle SHA..."
   bottle_sha=$(openssl sha256 < bottle.$platform.tar.gz | sed -e 's/(stdin)= //' -e 's/^SHA256//')
   echo "Bottle SHA-256: $bottle_sha"
-  sed -f /dev/stdin Formula/materialized.rb > Formula/materialized.rb.new <<EOF
+  sed -f /dev/stdin Formula/$formula.rb > Formula/$formula.rb.new <<EOF
 /^    sha256 $platform: .*/c\\
 \    sha256 $platform: "$bottle_sha"
 EOF
-  mv Formula/materialized.rb{.new,}
+  mv Formula/$formula.rb{.new,}
 done
 
-echo
-echo "Committing changes on new branch..."
-echo
-git checkout -b "v$version"
-git commit -am "v$version"
+# echo
+# echo "Committing changes on new branch..."
+# echo
+# git checkout -b "v$version"
+# git commit -am "v$version"
 
 # Clean up only if everything was successful, to ease debugging failures.
 rm bottle.*.tar.gz

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -41,16 +41,16 @@ for platform in mojave arm64_big_sur; do
   echo "Building bottle..."
   bin/mkbottle "$version" "$platform" "$formula"
 
-  # echo "Uploading bottle to S3..."
-  # if ! aws s3 cp bottle.$platform.tar.gz "s3://materialize-homebrew/$formula-$version.$platform.bottle.tar.gz"; then
-  #   echo
-  #   echo "Uploading to S3 failed." >&2
-  #   echo "AWS CLI access is documented here: https://github.com/MaterializeInc/i2/blob/main/doc/aws-access.md" >&2
-  #   echo "Ask for any clarification in #release on Slack." >&2
-  #   echo "Note:"
-  #   echo "    You need to be logged in to the mz-core-admin account"
-  #   exit 1
-  # fi
+  echo "Uploading bottle to S3..."
+  if ! aws s3 cp bottle.$platform.tar.gz "s3://materialize-homebrew/$formula-$version.$platform.bottle.tar.gz"; then
+    echo
+    echo "Uploading to S3 failed." >&2
+    echo "AWS CLI access is documented here: https://github.com/MaterializeInc/i2/blob/main/doc/aws-access.md" >&2
+    echo "Ask for any clarification in #release on Slack." >&2
+    echo "Note:"
+    echo "    You need to be logged in to the mz-core-admin account"
+    exit 1
+  fi
 
   echo "Updating formula for new bottle SHA..."
   bottle_sha=$(openssl sha256 < bottle.$platform.tar.gz | sed -e 's/(stdin)= //' -e 's/^SHA256//')
@@ -62,11 +62,11 @@ EOF
   mv Formula/$formula.rb{.new,}
 done
 
-# echo
-# echo "Committing changes on new branch..."
-# echo
-# git checkout -b "v$version"
-# git commit -am "v$version"
+echo
+echo "Committing changes on new branch..."
+echo
+git checkout -b "v$version"
+git commit -am "v$version"
 
 # Clean up only if everything was successful, to ease debugging failures.
 rm bottle.*.tar.gz

--- a/bin/mkbottle
+++ b/bin/mkbottle
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Builds the bottle for a new version of materialized.
+# Builds the bottle for a new version of a formula.
 #
 # Homebrew wants to manage the bottle-building process via `brew install
 # --build-bottle` and `brew bottle`, but these commands are tightly coupled to
@@ -20,8 +20,8 @@
 
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "usage: $0 VERSION PLATFORM" >&2
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 VERSION PLATFORM FORMULA" >&2
   exit 1
 fi
 
@@ -29,11 +29,12 @@ cd "$(dirname "$0")/.."
 
 version=${1#v}
 platform=$2
+formula=$3
 
 container=$(docker run --rm -d buildpack-deps:focal-curl sleep 999999)
 trap "docker kill $container > /dev/null" EXIT
 
-docker cp Formula/materialized.rb "$container:/materialized.rb"
+docker cp Formula/$formula.rb "$container:/$formula.rb"
 docker cp misc/mkbottle-inner.bash "$container:/mkbottle.bash"
-docker exec -i "$container" bash /mkbottle.bash "$version" "$platform"
+docker exec -i "$container" bash /mkbottle.bash "$version" "$platform" "$formula"
 docker cp "$container:/bottle.tar.gz" bottle.$platform.tar.gz


### PR DESCRIPTION
The first version of the `mz` CLI formula.

`v0.27.0-alpha.22.tar.gz` is the current _stable_ tag but not the latest. A tweak or change in the [bump-version](https://github.com/MaterializeInc/homebrew-materialize/blob/master/bin/bump-version) file is pending to make the CI/CD smoother.

It has been tested in `M1` and worked without a problem. Still, I've done it locally. A try from a clean Mac environment is pending. 