### PR TITLE
Add mz-deploy 0.1.0 formula

### DIFF
--- a/Formula/mz-deploy.rb
+++ b/Formula/mz-deploy.rb
@@ -1,0 +1,33 @@
+class MzDeploy < Formula
+  desc "Declarative SQL project tooling for Materialize"
+  homepage "https://materialize.com"
+  version "0.1.0"
+  license "BUSL-1.1"
+
+  on_macos do
+    on_arm do
+      url "https://binaries.materialize.com/mz-deploy-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "94d6f745b9a9d0180cc6194109753f99e7b3374facb7d41d1916476bf9a1566c"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://binaries.materialize.com/mz-deploy-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "673d1980d74b62a6e1e0a6cd7430aebd803d47903c2ef1198ca3532d4f14c49f"
+    end
+    on_arm do
+      url "https://binaries.materialize.com/mz-deploy-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "d3b4c28ce4d9a215416153af8aaec12fea4c668975b70f878be4efd498a530d6"
+    end
+  end
+
+  def install
+    bin.install "mz/bin/mz-deploy" => "mz-deploy"
+    generate_completions_from_executable(bin/"mz-deploy", "completions", shells: [:bash, :zsh, :fish])
+  end
+
+  test do
+    system "#{bin}/mz-deploy", "--version"
+  end
+end


### PR DESCRIPTION
Adds a Homebrew formula for the `mz-deploy` CLI (declarative SQL project tooling for Materialize), distributed as prebuilt tarballs from `binaries.materialize.com`.

## Details
- **Targets**: macOS `aarch64`, Linux `x86_64`, Linux `aarch64` — matching what `ci/deploy_mz-deploy` builds. There is no macOS Intel build, so it's intentionally omitted. Uses the OS-aware `on_macos`/`on_linux` DSL (the old `Hardware::CPU.arm?` style can't distinguish macOS-arm from Linux-arm).
- **Version**: `0.1.0`, from tag `mz-deploy-v0.1.0`.
- **Completions**: bash/zsh/fish are generated at install time via `generate_completions_from_executable` from the binary's `completions <shell>` subcommand (the official tarball ships only the binary).
- Binary is installed from `mz/bin/mz-deploy` inside the tarball.

## Checksums
| target | sha256 |
|---|---|
| aarch64-apple-darwin | `94d6f745b9a9d0180cc6194109753f99e7b3374facb7d41d1916476bf9a1566c` |
| x86_64-unknown-linux-gnu | `673d1980d74b62a6e1e0a6cd7430aebd803d47903c2ef1198ca3532d4f14c49f` |
| aarch64-unknown-linux-gnu | `d3b4c28ce4d9a215416153af8aaec12fea4c668975b70f878be4efd498a530d6` |

`brew style` passes with no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)