### PR TITLE
Fix mz-deploy install path

### DIFF
--- a/Formula/mz-deploy.rb
+++ b/Formula/mz-deploy.rb
@@ -23,7 +23,7 @@ class MzDeploy < Formula
   end
 
   def install
-    bin.install "mz/bin/mz-deploy" => "mz-deploy"
+    bin.install "bin/mz-deploy" => "mz-deploy"
     generate_completions_from_executable(bin/"mz-deploy", "completions", shells: [:bash, :zsh, :fish])
   end
 


### PR DESCRIPTION
## Problem

`brew install materializeinc/materialize/mz-deploy` fails with:

```
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - mz/bin/mz-deploy
```

## Cause

The release tarball has a single top-level directory (`mz/`). Homebrew automatically `cd`s into a lone top-level directory when staging an archive, so by the time the `install` block runs the working directory is already inside `mz/`. The formula referenced `mz/bin/mz-deploy` (the path from the archive root), which doesn't exist relative to `mz/`.

## Fix

Reference `bin/mz-deploy` instead, which is correct relative to the staged directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)